### PR TITLE
FIX Crash on multiple touch

### DIFF
--- a/app/src/main/java/com/example/yogasan/ThirdActivity.java
+++ b/app/src/main/java/com/example/yogasan/ThirdActivity.java
@@ -140,8 +140,10 @@ public class ThirdActivity extends AppCompatActivity {
     }
 
     private void stopTimer() {
-        countDownTimer.cancel();
-        mTimerRunning=false;
+        if (countDownTimer != null && mTimerRunning) {
+            countDownTimer.cancel();
+            mTimerRunning = false;
+        }
         button.setText("Start");
     }
 }


### PR DESCRIPTION
### Problem
There was a problem on reset ThirdActivity when switch back to SecondActivity that was causing crash. Timer was stopped but, because it is created in start method, if user never press on Start the timer was never instantiated.
### Solution
Add a check on stopTimer method to cancel the timer only if it was previously created